### PR TITLE
fix : expo 실행시 하단 오류메세지, 홈화면 메인로고 짤림

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,10 @@
       "tsconfigPaths": true
     },
 
+    "experimental": {
+      "newArchEnabled": true
+    },
+
     "plugins": [],
 
     "orientation": "portrait",

--- a/components/home/HomeScreen0.jsx
+++ b/components/home/HomeScreen0.jsx
@@ -38,7 +38,7 @@ export default function HomeScreen() {
 
       {/* 상단 헤더 (탭바 컬러 적용 대상) */}
       <View style={styles.headerWrapper}> 
-        <Text style={styles.logo}>moyeo</Text>
+        <Text style={styles.logo}>moyeo </Text>
         <View style={styles.profileContainer}>
           <TouchableOpacity onPress={() => navigation.navigate('EditProfile', user)}>
             {user?.image ? (


### PR DESCRIPTION
## fix: Expo 실행 시 하단 오류 메시지 및 홈화면 로고 짤림 수정

---

### ✅ 개요
- Expo 실행 환경에서 하단 오류바 지속 표시 문제 해결
- 홈화면 메인 로고 텍스트 짤림 현상 수정

---

### ✅ 배경
- Expo Go 환경에서 `newArchEnabled`가 강제 활성화되지만, 프로젝트 설정에 해당 항목이 명시되지 않아 UI 렌더링 오류 발생
- 홈화면에서 "MOYEO" 로고 텍스트의 오른쪽 일부가 잘려 보이는 현상 발생

---

### ✅ 변경 사항
- `app.json`에 `"experimental": { "newArchEnabled": true }` 설정 추가
- 로고 텍스트 문자열에 공백 1칸 추가하여 시각적 잘림 현상 보정

---

### ✅ 테스트 방법
1. `expo start`로 로컬 서버 실행
2. 스마트폰에서 **Expo Go** 앱으로 테스트
3. 하단 오류 메시지 표시 여부 확인
4. 홈화면에서 로고 짤림 현상 재현 여부 확인

---

### ✅ 기타 참고 사항
- `newArchEnabled`는 추후 다른 개발 환경에서도 일관성을 위해 반드시 설정 필요
- 공백 추가는 임시 해결책이며, 추후 레이아웃 조정으로 구조적 해결이 필요할 수 있음
