### PR TITLE
feat: 회원가입 및 프로필 수정 fetch api 전환

### DIFF
--- a/api/auth_fetch.js
+++ b/api/auth_fetch.js
@@ -1,9 +1,8 @@
 // 📁 api/auth_fetch.js
-// ✅ fetch 기반 회원가입, 사용자 조회, 프로필 수정 API 모음
-// - Axios 사용 없이 모든 요청을 fetch API로 구성함
-// - FormData 및 JSON 방식 요청 모두 대응
-// - JWT는 Authorization 헤더로 전달됨
-// - 프론트에서 이미지 포함 multipart 전송 및 JSON 수정 요청을 분리 처리
+// ✅ fetch 기반으로 구성된 API 함수 모음
+// - React Native (Expo Go 호환)
+// - 회원가입은 multipart/form-data 방식 + JSON을 파일처럼 처리
+// - 사용자 정보 조회 및 수정도 포함
 
 import * as Linking from 'expo-linking';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -36,13 +35,21 @@ export const redirectToOAuthWithFetch = async (provider) => {
 // ✅ fetch 기반 회원가입 API (multipart/form-data, key 분해 방식)
 export const registerUserWithFetch = async (userData, image, token) => {
   try {
-    console.log('🟡 [fetch] registerUser() 진입');
-    console.log('📦 userInfo:', userData);
-    console.log('🪪 token:', token);
-    console.log('🖼 image:', image ? image.uri : '없음');
-
     const formData = new FormData();
-    formData.append('userInfo', JSON.stringify(userData));
+
+    // ✅ JSON을 파일처럼 추가 (Base64 방식 , expo go에서는 RNfs 사용불가)
+    formData.append('userInfo', {
+      uri: 'data:application/json;base64,' + btoa(unescape(encodeURIComponent(JSON.stringify(userData)))),
+      type: 'application/json',
+      name: 'userInfo.json',
+    });
+    // console.log('🟡 [fetch] registerUser() 진입');
+    // console.log('📦 userInfo:', userData);
+    // console.log('🪪 token:', token);
+    // console.log('🖼 image:', image ? image.uri : '없음');
+
+    // const formData = new FormData();
+    // formData.append('userInfo', JSON.stringify(userData));
 
     if (image) {
       formData.append('profileImage', {
@@ -121,10 +128,13 @@ export const getUserInfoWithFetch = async (token) => {
  * @param {string} token - JWT 토큰
  * @returns {Object} 서버 응답 (수정된 사용자 정보)
  */
-export const editUserProfileWithFetch = async (userInfo, image, token) => {
+export const editUserProfileWithFetch = async (userData, token) => {
   const requestBody = {
-    userInfo,
-    profileImage: image, // null 또는 { uri: ... } 형식
+    nickname: userData.nickname,
+    gender: userData.gender,
+    age: userData.age,
+    mbti: userData.mbti,
+    profileImageUrl: userData.profileImageUrl || null, //  프로필 이미지 URL (없으면 null)
   };
 
   const response = await fetch(`${BASE_URL}/user/edit`, {
@@ -132,6 +142,7 @@ export const editUserProfileWithFetch = async (userInfo, image, token) => {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      Accept: 'application/json',
     },
     body: JSON.stringify(requestBody),
   });

--- a/components/auth/UserInfoScreen.jsx
+++ b/components/auth/UserInfoScreen.jsx
@@ -1,4 +1,6 @@
 // 📁 components/auth/UserInfoScreen.jsx
+
+// 회원가입 요쳥과 유저 정보 재조회는 fetch를 사용.
 import React, { useState, useContext, useEffect } from 'react';
 import {
   View,
@@ -19,7 +21,7 @@ import * as Linking from 'expo-linking'; // ✅ 딥링크 파싱용 추가
 import { UserContext } from '../../contexts/UserContext';
 import ProfileImagePicker from '../common/ProfileImagePicker';
 import Dropdown from '../common/Dropdown';  // DropdownPicker 기반 Dropdown
-import { registerUser, getUserInfo } from '../../api/auth'; // 🔁 나중에 사용 시 주석 해제
+import { registerUserWithFetch, getUserInfoWithFetch } from '../../api/auth_fetch'; // 회원가입은 fetch 사용
 
 export default function UserInfoScreen() {
   const navigation = useNavigation();
@@ -52,7 +54,7 @@ export default function UserInfoScreen() {
     handleInitialLink();
   }, []);
    
-  // 가입 시작하기
+  // 가입 시작하기 (회원가입 요청)
   const handleSubmit = async () => {
     const token = await AsyncStorage.getItem('jwt');
     const isMock = await AsyncStorage.getItem('mock');
@@ -76,7 +78,7 @@ export default function UserInfoScreen() {
     }
 
     try {
-      const result = await registerUser(userData, image, token);
+      const result = await registerUserWithFetch(userData, image, token);  // fetch 함수 호출
       console.log(' registerUser 응답:', result);
 
       const newToken = result.token || token;
@@ -86,7 +88,7 @@ export default function UserInfoScreen() {
         console.warn('⚠️ 응답에 정식 토큰 없음 → 임시 토큰 계속 사용');
       }
 
-      const newUser = await getUserInfo(newToken);
+      const newUser = await getUserInfoWithFetch(newToken); // fetch 함수 사용
 
       setUser(newUser);
       await AsyncStorage.setItem('user', JSON.stringify(newUser));

--- a/components/profile/EditProfileScreen.jsx
+++ b/components/profile/EditProfileScreen.jsx
@@ -18,7 +18,8 @@ import { useNavigation } from '@react-navigation/native';
 import { UserContext } from '../../contexts/UserContext';
 import ProfileImagePicker from '../common/ProfileImagePicker';
 import Dropdown from '../common/Dropdown'; // DropDownPicker 기반
-import { editUserProfile, getUserInfo } from '../../api/auth'; // api 오프 시시 주석 유지, getUserInfo 추가
+// import { editUserProfile, getUserInfo } from '../../api/auth'; // api 오프 시시 주석 유지, getUserInfo 추가
+import { editUserProfileWithFetch, getUserInfoWithFetch } from '../../api/auth_fetch'; // ✅ fetch 기반 API 사용
 
 export default function EditProfileScreen() {
   const navigation = useNavigation();
@@ -59,17 +60,32 @@ export default function EditProfileScreen() {
     }
 
     try {
-      await editUserProfile(userData, image, token);
-      const updated = await getUserInfo(token);
+      await editUserProfileWithFetch(userData, token); // ✅ fetch로 수정 요청
+      const updated = await getUserInfoWithFetch(token); // ✅ fetch로 사용자 정보 다시 조회
       setUser(updated);
       await AsyncStorage.setItem('user', JSON.stringify(updated));
       Alert.alert('성공', '프로필이 수정되었습니다.');
       navigation.goBack();
     } catch (e) {
-      console.error('프로필 저장 실패:', e);
+      console.error('❌ 프로필 저장 실패:', e);
       Alert.alert('실패', '프로필 저장에 실패했습니다.');
     }
   };
+
+  //   // 기존 axios api 함수인 editUserProfile
+  //   try {
+  //     await editUserProfile(userData, image, token);
+  //     const updated = await getUserInfo(token);
+  //     setUser(updated);
+  //     await AsyncStorage.setItem('user', JSON.stringify(updated));
+  //     Alert.alert('성공', '프로필이 수정되었습니다.');
+  //     navigation.goBack();
+  //   } catch (e) {
+  //     console.error('프로필 저장 실패:', e);
+  //     Alert.alert('실패', '프로필 저장에 실패했습니다.');
+  //   }
+  // };
+
   return (
     <SafeAreaView style={styles.safe}>
       <KeyboardAvoidingView


### PR DESCRIPTION
feat: 회원가입 및 프로필 수정 기능 fetch 기반으로 전환

1. 개요  
- axios 기반으로 작성된 회원가입 및 프로필 수정 로직을 fetch 기반으로 전환  
- Expo Go 환경 및 multipart/form-data 처리 문제를 고려하여 안정성 향상  
- 서버(Spring)의 @RequestPart 요구사항에 맞는 구조 구현

2. 배경  
- React Native (Expo Go) 환경에서 axios + multipart/form-data 사용 시 boundary가 깨지는 문제 발생  
- 특히 JSON 데이터를 파일처럼 보내야 하는 Spring 구조(@RequestPart)와 충돌  
- RNFS(react-native-fs)를 사용할 수 없는 Expo Go 환경의 제약으로 인해 JSON 파일 직접 생성 불가능  
- 기존 방식으로는 백엔드에 요청이 도달하지 않거나 400/415 에러 발생

3. 변경 사항  
- `auth_fetch.js` 파일 생성 및 다음 함수 구현:  
  - `registerUserWithFetch()` : Base64 인코딩을 통한 JSON 파일처럼 전송 (FormData)  
  - `editUserProfileWithFetch()` : 단순 JSON 구조 PUT 요청 (FormData 아님)  
  - `getUserInfoWithFetch()` : 사용자 정보 조회 (GET 요청)  
- `UserInfoScreen.jsx` : 회원가입 fetch 방식으로 전환  
- `EditProfileScreen.jsx` : 프로필 수정 fetch 방식으로 전환  
- FormData 구성 시 Content-Type 명시 제거 → fetch가 자동으로 처리

4. 테스트 방법  
1. `expo start`로 앱 실행  
2. 회원가입 화면에서 정보 입력 후 전송  
   - userInfo가 파일처럼 FormData로 보내지고 백엔드에서 정상 파싱됨 확인  
3. 프로필 편집 화면에서 정보 수정 후 저장  
   - JSON 형식으로 전송되어 DTO에 정상 매핑되는지 확인  
4. 가입 및 수정 후 getUserInfo 호출 → 응답값이 UserContext에 반영되는지 확인

5. 기타 참고 사항  
- axios는 OAuth 로그인 및 딥링크 흐름에서는 유지 중  
- fetch는 이미지 업로드 + multipart 처리를 포함하는 요청에만 사용  
- FormData에는 Content-Type 수동 설정을 하지 않아야 정상 동작 (자동 boundary 적용)  
- Base64 인코딩은 RNFS를 사용할 수 없는 Expo Go 환경의 우회 방식임  
- 이후 앱 빌드 전환 시 RNFS 방식으로도 전환 가능성 있음

