### PR TITLE
MBTI 드롭다운 호환 및 프로필 편집 시 기존 MBTI 불러오기 버그 수정

### DIFF
--- a/components/auth/UserInfoScreen.jsx
+++ b/components/auth/UserInfoScreen.jsx
@@ -19,9 +19,14 @@ import * as Linking from 'expo-linking'; // ✅ 딥링크 파싱용 추가
 
 import { UserContext } from '../../contexts/UserContext';
 import ProfileImagePicker from '../common/ProfileImagePicker';
-import Dropdown from '../common/Dropdown'; // DropdownPicker 기반 Dropdown
+
 import { registerUserWithFetch, getUserInfoWithFetch } from '../../api/auth_fetch'; // 회원가입은 fetch 사용
 import { MaterialIcons } from '@expo/vector-icons'; 
+
+const Dropdown = Platform.OS === 'ios'
+  ? require('../common/Dropdown').default    // iOS: 기존 Dropdown
+  : require('../auth/common/DropdownAndroid').default;  // 그 외: 안드로이드 드롭다운
+  //: require('../auth/common/DropdownAndroid').default;  // 그 외: 안드로이드 드롭다운
 
 // ==== 반응형 유틸 함수 ====
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');

--- a/components/auth/common/DropdownAndroid.jsx
+++ b/components/auth/common/DropdownAndroid.jsx
@@ -1,0 +1,91 @@
+// auth/common/DropdownAndroid.jsx
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, FlatList } from 'react-native';
+
+// props: label, selectedValue, onValueChange, items (label, value)
+export default function DropdownAndroid({ label, selectedValue, onValueChange, items }) {
+  const [visible, setVisible] = React.useState(false);
+
+  return (
+    <View style={styles.container}>
+      {label && <Text style={styles.label}>{label}</Text>}
+      <TouchableOpacity
+        style={styles.dropdown}
+        onPress={() => setVisible(true)}
+      >
+        <Text style={styles.text}>
+          {items.find(i => i.value === selectedValue)?.label || '선택안함'}
+        </Text>
+      </TouchableOpacity>
+      <Modal
+        visible={visible}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setVisible(false)}
+      >
+        <TouchableOpacity style={styles.overlay} onPress={() => setVisible(false)}>
+          <View style={styles.modalContent}>
+            <FlatList
+              data={items}
+              keyExtractor={(item) => item.value}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={styles.item}
+                  onPress={() => {
+                    setVisible(false);
+                    onValueChange(item.value);
+                  }}
+                >
+                  <Text style={styles.text}>{item.label}</Text>
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { 
+    width: '100%',
+     marginBottom: 10 
+},
+  label: { 
+    fontSize: 16, 
+    color: '#374151', 
+    marginBottom: 4, 
+    fontWeight: '400' 
+},
+  dropdown: { 
+    borderColor: '#D1D5DB', 
+    borderWidth: 1, borderRadius: 8, 
+    backgroundColor: '#fff', padding: 12, 
+    minHeight: 40, 
+    justifyContent: 'center' 
+},
+  text: { 
+    fontSize: 16, 
+    color: '#111827', 
+    textAlign: 'left' 
+},
+  overlay: { 
+    flex: 1, 
+    backgroundColor: 'rgba(0,0,0,0.25)', 
+    justifyContent: 'center' 
+},
+  modalContent: { 
+    backgroundColor: '#fff',
+    marginHorizontal: 40,
+    borderRadius: 8,
+    maxHeight: 300,
+    padding: 10 
+},
+  item: { 
+    padding: 14, 
+    borderBottomWidth: 1, 
+    borderBottomColor: '#eee' 
+},
+
+});

--- a/components/common/Dropdown.jsx
+++ b/components/common/Dropdown.jsx
@@ -16,6 +16,11 @@ export default function Dropdown({ label, selectedValue, onValueChange, items })
   const [value, setValue] = useState(selectedValue);
   const [options, setOptions] = useState(items);
 
+  // selectedValue가 바뀔 때마다 value도 맞춰줌!
+  React.useEffect(() => {
+    setValue(selectedValue);
+  }, [selectedValue]);
+
   const handleChangeValue = (val) => {
     setValue(val);
     onValueChange(val);
@@ -33,6 +38,8 @@ export default function Dropdown({ label, selectedValue, onValueChange, items })
         setValue={handleChangeValue}
         setItems={setOptions}
         placeholder="선택안함"
+        closeOnBackPressed={true} // 뒤로가기 시 닫힘
+        closeOnBlur={true}        // 외부 터치 시 닫힘
         style={[styles.dropdown, { zIndex: 1000 }]} // ✅ 다른 컨포넌트와 결치해 방지
         textStyle={styles.text}
         dropDownContainerStyle={[

--- a/components/profile/EditProfileScreen.jsx
+++ b/components/profile/EditProfileScreen.jsx
@@ -17,12 +17,17 @@ import {
 import { MaterialIcons } from '@expo/vector-icons'; // 뒤로가기 + 로그아웃 아이콘
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
-
 import { UserContext } from '../../contexts/UserContext';
 import ProfileImagePicker from '../common/ProfileImagePicker';
-import Dropdown from '../common/Dropdown'; // DropDownPicker 기반
-
 import { editUserProfileWithFetch, getUserInfoWithFetch, urlToBase64ProfileImage } from '../../api/auth_fetch'; // ✅ fetch 기반 API 사용
+
+
+// iOS는 기존 Dropdown, 그 외 OS는 DropdownAndroid 사용
+const Dropdown = Platform.OS === 'ios'
+  ? require('../common/Dropdown').default
+  //: require('../common/Dropdown').default;
+  : require('../auth/common/DropdownAndroid').default;
+
 
 // ==== 반응형 유틸 함수 ====
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -70,7 +75,7 @@ const ageInputRef = useRef(null);
         setNickname(user?.nickname || '');
         setGender(user?.gender === 'MALE' ? '남성' : user?.gender === 'FEMALE' ? '여성' : '');
         setAge(user?.age?.toString() || '');
-        setMbti(user?.mbti || '');
+        setMbti((user?.mbti || '').toUpperCase());
         setImage(user?.profileImageUrl || null);
       } else {
         try {
@@ -78,7 +83,7 @@ const ageInputRef = useRef(null);
           setNickname(freshUser.nickname || '');
           setGender(freshUser.gender === 'MALE' ? '남성' : freshUser.gender === 'FEMALE' ? '여성' : '');
           setAge(freshUser.age?.toString() || '');
-          setMbti(freshUser.mbti || '');
+          setMbti((freshUser.mbti || '').toUpperCase());
           setImage(freshUser.profileImageUrl || null);
         } catch (e) {
           console.error('❌ 사용자 정보 조회 실패:', e);

--- a/components/profile/ProfileHomeScreen.jsx
+++ b/components/profile/ProfileHomeScreen.jsx
@@ -90,30 +90,19 @@ export default function ProfileHomeScreen({ route }) {
 
           {/* 정보 표시 */}
           <View style={styles.infoContainer}>
-            <View style={styles.infoRowWrapper}>
-              <View style={styles.infoColumn}>
-                <Text style={styles.label}>닉네임</Text>
-                <Text style={styles.label}>성별</Text>
-                <Text style={styles.label}>나이</Text>
-                <Text style={styles.label}>MBTI</Text>
-              </View>
-              <View style={styles.infoColumn}>
-                <Text style={styles.value}>{user?.nickname || '-'}</Text>
-                <Text style={styles.value}>
-                  {user?.gender === 'MALE'
-                    ? '남성'
-                    : user?.gender === 'FEMALE'
-                    ? '여성'
-                    : '-'}
-                </Text>
-                <Text style={[styles.value, styles.boldValue]}>
-                  {user?.age ? String(user.age) : '-'}
-                </Text>
-                <Text style={[styles.value, styles.boldValue]}>
-                  {user?.mbti || '-'}
-                </Text>
-              </View>
-            </View>
+            <View style={styles.infoBox}>
+  {[
+    { label: '닉네임', value: user?.nickname || '-' },
+    { label: '성별', value: user?.gender === 'MALE' ? '남성' : user?.gender === 'FEMALE' ? '여성' : '-' },
+    { label: '나이', value: user?.age ? String(user.age) : '-' },
+    { label: 'MBTI', value: user?.mbti || '-' },
+  ].map((item, idx) => (
+    <View key={idx} style={styles.infoRow}>
+      <Text style={styles.label}>{item.label}</Text>
+      <Text style={styles.value}>{item.value}</Text>
+    </View>
+  ))}
+</View>
           </View>
         </View>
 
@@ -266,5 +255,37 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#FFFFFF',
     letterSpacing: 0.2,
+  },
+  infoBox: {
+    width: '100%',
+    paddingHorizontal: normalize(20),
+    marginTop: normalize(50, 'height'),
+    // rowGap은 RN 최신 버전에서만 동작 → 하위 호환 위해 생략하거나 marginBottom 사용
+  },
+
+  infoRow: {
+    flexDirection: 'row',           // 가로 정렬
+    justifyContent: 'center',       // 전체 줄 가운데 배치
+    alignItems: 'center',           // 라벨과 값의 세로 기준선 정렬 ← 중요!
+    marginBottom: normalize(20),    // 줄 간 간격
+  },
+
+  label: {
+    fontSize: normalize(18),
+    fontWeight: '700',
+    color: '#1E1E1E',
+    textAlign: 'center',
+    lineHeight: normalize(24),
+    minWidth: normalize(80),
+    marginRight: normalize(16),     // 라벨과 값 사이 간격
+  },
+
+  value: {
+    fontSize: normalize(18),
+    fontWeight: '400',
+    color: '#1E1E1E',
+    textAlign: 'center',
+    lineHeight: normalize(24),
+    minWidth: normalize(80),
   },
 });


### PR DESCRIPTION
<!-- # [브랜치 타입] 작업개요(한글)  -->
<!-- 예: # [feature] 로그인 페이지 UI 구성 -->
# []


---

## 📝 요약(Summary)
MBTI 드롭다운 호환 및 프로필 편집 시 기존 MBTI 불러오기 버그 수정

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
안드로이드 기준 회원가입 및 프로필 편집시, mbti 선택 및 변경에 사용되는 드롭다운 모듈을 작동 가능하게 전용 모듈 추가,  프로필 편집 시에 mbti가 기존 데이터를 부르지 못한 현상을 수정
---

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## ✅ 주요 변경사항
<!-- 핵심 코드/기능 변경 리스트 -->
- 

---

## 🧪 테스트 내역
<!-- 직접 실행해본 내역, 콘솔 로그, 스크린샷 등 첨부 -->
- [ ] 

> 실행 스크린샷
> 

---

## 📎 관련 이슈
<!-- 관련된 이슈번호가 있으면 연결 -->
<!-- 예: Closes #12 -->

---

## 🙏 리뷰 요청 사항
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 

---

## 🧹 기타 참고 사항
<!-- 추가로 공유하고 싶은 내용 -->
- 


